### PR TITLE
typo fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
 | 1xxx xxxx | 0001 xxxx |
 +...........+-----------+
 </code></pre></div></li>
-<li><p>There are 4 bits in the lat byte can be used to store the value of <code>length of Blob</code>.</p>
+<li><p>There are 4 bits in the last byte which can be used to store the value of <code>length of Blob</code>.</p>
 <div class="highlight"><pre><code class="language-text" data-lang="text">                                     binary data
 +-----------+...........+-----------+============+
 | 1xxx xxxx | 1xxx xxxx | 0001 xxxx |    data    |


### PR DESCRIPTION
I've noticed something which i believe is a typo error with the word "last" being written as "lat" so went ahead and fixed it.

After fixing and reading, it seemed that a word was missing so i added "which" to make a somewhat proper sentence.